### PR TITLE
Mise à jour de la date et de l'utilisateur lors de la duplication d'inventaire

### DIFF
--- a/gr_project_inventory/models/models.py
+++ b/gr_project_inventory/models/models.py
@@ -593,7 +593,9 @@ class GrInternalInventory(models.Model):
         # Créer une copie avec les champs voulus vides
         new_record = self.copy({
             'serial_number': False,
-            'asset_tag': False
+            'asset_tag': False,
+            'created_at': fields.Datetime.now(),  # Utiliser la date actuelle
+            'created_by_id': self.env.user.id,   # Utiliser l'utilisateur actuel
         })
         # Pas de retour d'action, la ligne sera ajoutée directement dans la vue tree
         return True
@@ -603,7 +605,9 @@ class GrInternalInventory(models.Model):
         # Créer une copie avec les champs voulus vides
         new_record = self.copy({
             'serial_number': False,
-            'asset_tag': False
+            'asset_tag': False,
+            'created_at': fields.Datetime.now(),  # Utiliser la date actuelle
+            'created_by_id': self.env.user.id,   # Utiliser l'utilisateur actuel
         })
         
         # Retourner une action qui ouvre la vue en mode édition sur la nouvelle ligne


### PR DESCRIPTION
Cette PR implémente la tâche 'Développement : Internal Inventory : mise a jour de la date ACTUELLE en cas de duplication ainsi que le nom du collaborateur qui duplique' mentionnée dans le TODO.md. Modifications: - Mise à jour des méthodes action_duplicate_line et action_duplicate_line_in_act_window pour définir la date actuelle (created_at) lors de la duplication - Mise à jour de l'utilisateur (created_by_id) avec l'utilisateur actuel lors de la duplication. Cela garantit que les éléments dupliqués auront la date actuelle et l'identité du collaborateur qui effectue la duplication.